### PR TITLE
fixing  'charmap' codec can't encode character bug

### DIFF
--- a/mrgenerator/readme.py
+++ b/mrgenerator/readme.py
@@ -13,7 +13,7 @@ def write_readme(name=None, path=None):
     env = Environment(loader=FileSystemLoader(utils.get_templates_dir()))
     template = env.get_template('default.pmd')
     filename = os.path.join(path, name)
-    with open(filename, 'w') as fh:
+    with open(filename, 'w', encoding='utf-8') as fh:
         fh.write(template.render(
             data=infos.get_info_readme(),
             datetime=datetime

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
 
-with open('requirements.txt') as f:
+with open('requirements.txt', encoding='utf-8') as f:
     requirements = f.read().splitlines()
 
 setuptools.setup(


### PR DESCRIPTION
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f44b' in position 50: character maps to <undefined>

fix